### PR TITLE
Remove legit domain.

### DIFF
--- a/index.json
+++ b/index.json
@@ -84131,7 +84131,6 @@
   "polycast-suzhou.com",
   "polycoco.com",
   "polyfaust.com",
-  "polyformat.media",
   "polyfox.xyz",
   "polymnestore.co",
   "polymorph.icu",


### PR DESCRIPTION
I have no idea how this domain ended up here but since at least early 2020 my company uses it as the primary method of communication via a legit provider. I can guarantee that it doesn't provide any kind of "disposable" email-addresses to anyone. :)