### PR TITLE
Remove caliburn.us (legitimate corporate domain)

### DIFF
--- a/index.json
+++ b/index.json
@@ -24040,7 +24040,6 @@
   "caliberaccountinggroup.com",
   "calibericvilafrancadelpenedes.com",
   "calibra-travel.com",
-  "caliburn.us",
   "califityoga.com",
   "califohdsj.space",
   "california-resident-agent.com",


### PR DESCRIPTION
caliburn.us is a legitimate corporate email domain for Caliburn
Technologies (a defense technology company in Austin, Texas). It is
not a disposable or temporary email provider. It was most likely
added while the domain was dormant before the company launched.

Evidence that this is an active, authenticated corporate domain:
- MX -> Microsoft 365 (caliburn-us.mail.protection.outlook.com)
- SPF valid: v=spf1 include:spf.protection.outlook.com -all
- DKIM valid (Microsoft 365 selector1 active; Mailchimp selectors)
- DMARC published (p=quarantine)
- Live test mail passes SPF, DKIM, and DMARC
- Spamhaus clean; not on DBL / SURBL / URIBL
- Domain verified with Microsoft, Apple, Miro, and Notion

This PR removes the caliburn.us entry from index.json. Please also
remove it from any generated or derived files if applicable.