### PR TITLE
Removal request: zamana.com legitimate corporate domain, listing predates current ownership

### DIFF
--- a/index.json
+++ b/index.json
@@ -131963,7 +131963,6 @@
   "zalocasino.xyz",
   "zaltak.com",
   "zalvisual.us",
-  "zamana.com",
   "zamananow.com",
   "zamasd.top",
   "zambezinationalparks.com",


### PR DESCRIPTION
Hi, please remove zamana.com from the list. zamana.com is the corporate email domain of Zamana Inc.

The domain (registered since 2004) was acquired by the company in October 2025; any disposable-email activity predates our ownership. It was first flagged around 2019, years before the company existed.

There is no public email signup or address-generation service on this domain today.

Current setup, publicly verifiable: business email on Google Workspace (MX: smtp.google.com), published SPF and DMARC.

The stale listing is blocking employees from registering for services.

Happy to provide further verification. Thank you!

domain marked safe on https://verifymail.io/domain/zamana.com
<img width="1267" height="937" alt="image" src="https://github.com/user-attachments/assets/8c0574bb-d21e-4e91-a39c-e196a2fbb026" />
